### PR TITLE
Exception при попытке получить доступ к заблокированной строке

### DIFF
--- a/onlinestore/src/main/java/com/konstantinov/onlinestore/OnlinestoreApplication.java
+++ b/onlinestore/src/main/java/com/konstantinov/onlinestore/OnlinestoreApplication.java
@@ -2,8 +2,10 @@ package com.konstantinov.onlinestore;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @SpringBootApplication
+@EnableTransactionManagement
 public class OnlinestoreApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(OnlinestoreApplication.class, args);

--- a/onlinestore/src/main/java/com/konstantinov/onlinestore/bd/goods/CakeEntity.java
+++ b/onlinestore/src/main/java/com/konstantinov/onlinestore/bd/goods/CakeEntity.java
@@ -14,7 +14,6 @@ import java.util.*;
 @RequiredArgsConstructor
 @Table(name = "CAKE")
 public class CakeEntity {
-
     @Setter(AccessLevel.NONE)
     private @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;

--- a/onlinestore/src/main/java/com/konstantinov/onlinestore/bd/goods/CakeRepository.java
+++ b/onlinestore/src/main/java/com/konstantinov/onlinestore/bd/goods/CakeRepository.java
@@ -1,7 +1,16 @@
 package com.konstantinov.onlinestore.bd.goods;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
+
+import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
 
 public interface CakeRepository extends JpaRepository<CakeEntity, Long> {
     CakeEntity getById(Long id);
+
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "0")})
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    CakeEntity getFirstBy();
 }

--- a/onlinestore/src/main/java/com/konstantinov/onlinestore/bd/goods/CakeService.java
+++ b/onlinestore/src/main/java/com/konstantinov/onlinestore/bd/goods/CakeService.java
@@ -13,4 +13,5 @@ public interface CakeService {
     List<Cake> getSomeCake(Integer page, Integer size);
     void updateCake(Cake cake);
     void updateOrCreateCakeDetail(CakeDetail cakeDetail);
+    void getAnyCake() throws InterruptedException;
 }

--- a/onlinestore/src/main/java/com/konstantinov/onlinestore/bd/goods/CakeServiceImpl.java
+++ b/onlinestore/src/main/java/com/konstantinov/onlinestore/bd/goods/CakeServiceImpl.java
@@ -4,17 +4,20 @@ import com.konstantinov.onlinestore.bd.orders.OrderEntity;
 import com.konstantinov.onlinestore.rest.dto.Cake;
 import com.konstantinov.onlinestore.rest.dto.CakeDetail;
 import com.konstantinov.onlinestore.rest.dto.Cakes;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 public class CakeServiceImpl implements CakeService {
     private final CakeRepository cakeRepository;
     private final CompositionRepository compositionRepository;
@@ -30,6 +33,15 @@ public class CakeServiceImpl implements CakeService {
         Cakes cakes = new Cakes();
         cakes.setCakeList(getSomeCake(0, 1000));
         return cakes;
+    }
+
+    @Override
+    @Transactional
+    public void getAnyCake() throws InterruptedException {
+        CakeEntity cake = cakeRepository.getFirstBy();
+        log.warn("{}", cake);
+        Thread.sleep(5000);
+        return;
     }
 
 

--- a/onlinestore/src/main/java/com/konstantinov/onlinestore/rest/advice/CakeAdvice.java
+++ b/onlinestore/src/main/java/com/konstantinov/onlinestore/rest/advice/CakeAdvice.java
@@ -6,11 +6,17 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+
 @ControllerAdvice
 public class CakeAdvice {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(CakeNotFoundException.class)
     public void cakeNotFound(){
+
+    }
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(org.hibernate.PessimisticLockException.class)
+    public void transactionException(org.hibernate.PessimisticLockException ex){
 
     }
 }

--- a/onlinestore/src/main/java/com/konstantinov/onlinestore/rest/controller/CakeController.java
+++ b/onlinestore/src/main/java/com/konstantinov/onlinestore/rest/controller/CakeController.java
@@ -38,4 +38,9 @@ public class CakeController {
     public void addCake(@Valid @RequestBody CakeDetail cake){
         cakeService.updateOrCreateCakeDetail(cake);
     }
+
+    @GetMapping(value = "testTransaction")
+    public void test() throws InterruptedException {
+        cakeService.getAnyCake();
+    }
 }


### PR DESCRIPTION
Exception при попытке получить доступ к заблокированной строке все-таки можно получить при помощи @'QueryHint, если для javax.persistence.lock.timeout указать value="0", именно это значение отвечает за поведение "NO_WAIT". Исключение ловлю в ControllerAdvice и в нем я устанавливаю response status 409. 
Еще я нашел занимательный способ эмитировать такой конкурентный доступ. Мне не хотелось создавать вручную потоки, ведь это не реалистичная ситуация. 
Я оставил Thread.sleep, но запросы, как и на нашей паре, выполнялись последовательно. Но ведь так быть не должно. Оказывается, они выполняются последовательно, если их отправлять из одного браузера... Вот на скриншоте я отправил один запрос из браузера, а один запрос из curl и запросы начали выполняться параллельно. Причем они должны быть отправлены именно из разных мест: если отправить два запроса из curl, то запросы все равно будут выполняться последовательно.
Также запросы будут работать параллельно, если, например, один запрос отправить из браузера, а другой из браузера, но в гостевом режиме. В общем интересное поведение, будто spring(или tomcat? или кто этим вообще рулит?) выделяет один поток на одного "клиента"
![Test](https://user-images.githubusercontent.com/90114057/154969578-caabbff0-c4c5-49f0-9fcd-34c849539f2b.png)
.